### PR TITLE
Bump java chart

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ configurations.all {
   resolutionStrategy {
     eachDependency { DependencyResolveDetails details ->
       if (details.requested.group in ['com.fasterxml.jackson.core', 'com.fasterxml.jackson.module', 'com.fasterxml.jackson.datatype']) {
-        details.useVersion '2.9.9'
+        details.useVersion '2.10.1'
       }
     }
   }

--- a/charts/ccd-test-stubs-service/Chart.yaml
+++ b/charts/ccd-test-stubs-service/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for ccd-test-stubs-service App
 name: ccd-test-stubs-service
 home: https://github.com/hmcts/ccd-test-stubs-service
-version: 1.0.1
+version: 1.0.2
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/charts/ccd-test-stubs-service/requirements.yaml
+++ b/charts/ccd-test-stubs-service/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: java
-    version: ~2.7.1
+    version: ~2.15.0
     repository: '@hmctspublic'


### PR DESCRIPTION
bulk-scanning is currently blocked because of a clash in the tpl in an old version of chart-java, this was fixed in ~2.10