### PR TITLE
RDM-7114: ccd-test-stubs-service is not building on master. 2020 vuln…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ def versions = [
 dependencyManagement {
   dependencies {
     // CVE-2019-0232 - command line injections on windows - fixed on spring boot master but not released
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.19') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.30') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'


### PR DESCRIPTION
RDM-7114: ccd-test-stubs-service is not building on master. 2020 vulnerability issues.
    
            [RDM-7114] (https://tools.hmcts.net/jira/browse/RDM-7114).