### PR TITLE
ACA-68: Callback to simulate completed NOC request

### DIFF
--- a/wiremock/mappings/ccd/callback_returning_simulated_completed_noc_request.json
+++ b/wiremock/mappings/ccd/callback_returning_simulated_completed_noc_request.json
@@ -26,17 +26,22 @@
           "OrgPolicyReference": "RespondentPolicy",
           "OrgPolicyCaseAssignedRole": "[RespondentSolicitor]"
         },
-        "otherPartyOrganisationPolicy": {
-          "Organisation": null,
-          "OrgPolicyReference": "OtherPartyPolicy",
-          "OrgPolicyCaseAssignedRole": "[OtherPartySolicitor]"
-        },
 
         "changeOrganisationRequestField": {
+          "Reason": null,
           "CaseRoleId": null,
+          "NotesReason": null,
+          "ApprovalStatus": null,
           "RequestTimestamp": null,
-          "OrganisationToAdd": null,
-          "OrganisationToRemove": null
+          "OrganisationToAdd": {
+            "OrganisationID": null,
+            "OrganisationName": null
+          },
+          "OrganisationToRemove": {
+            "OrganisationID": null,
+            "OrganisationName": null
+          },
+          "ApprovalRejectionTimestamp": null
         }
       }
     },

--- a/wiremock/mappings/ccd/callback_returning_simulated_completed_noc_request.json
+++ b/wiremock/mappings/ccd/callback_returning_simulated_completed_noc_request.json
@@ -1,0 +1,47 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/callback_returning_simulated_completed_noc_request"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "data": {
+        "applicantOrganisationPolicy": {
+          "Organisation": {
+            "OrganisationID": "QUK822N",
+            "OrganisationName": "BEFTA Organisation"
+          },
+          "OrgPolicyReference": "ApplicantPolicy",
+          "OrgPolicyCaseAssignedRole": "[ApplicantSolicitor]"
+        },
+        "respondentOrganisationPolicy": {
+          "Organisation":  {
+            "OrganisationID": "QUK822N",
+            "OrganisationName": "BEFTA Organisation"
+          },
+          "OrgPolicyReference": "RespondentPolicy",
+          "OrgPolicyCaseAssignedRole": "[RespondentSolicitor]"
+        },
+        "otherPartyOrganisationPolicy": {
+          "Organisation": null,
+          "OrgPolicyReference": "OtherPartyPolicy",
+          "OrgPolicyCaseAssignedRole": "[OtherPartySolicitor]"
+        },
+
+        "changeOrganisationRequestField": {
+          "CaseRoleId": null,
+          "RequestTimestamp": null,
+          "OrganisationToAdd": null,
+          "OrganisationToRemove": null
+        }
+      }
+    },
+    "transformers": [
+      "dynamic-case-data-response-transformer"
+    ]
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[ACA-68](https://tools.hmcts.net/jira/browse/ACA-68) _"3.3.6 NoCRequest API"_

### Change description ###

Added a callback stub to simulate an approved NOC request that has been processed by `CheckForNoCApproval` and `ApplyNoCDecision`.

This test stub should no longer be required once these APIs are ready.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
