### PR TITLE
ACA-68: Update simulate completed NOC request

### DIFF
--- a/wiremock/mappings/ccd/callback_returning_simulated_completed_noc_request.json
+++ b/wiremock/mappings/ccd/callback_returning_simulated_completed_noc_request.json
@@ -12,16 +12,14 @@
       "data": {
         "applicantOrganisationPolicy": {
           "Organisation": {
-            "OrganisationID": "QUK822N",
-            "OrganisationName": "BEFTA Organisation"
+            "OrganisationID": "QUK822N"
           },
           "OrgPolicyReference": "ApplicantPolicy",
           "OrgPolicyCaseAssignedRole": "[ApplicantSolicitor]"
         },
         "respondentOrganisationPolicy": {
           "Organisation":  {
-            "OrganisationID": "QUK822N",
-            "OrganisationName": "BEFTA Organisation"
+            "OrganisationID": "QUK822N"
           },
           "OrgPolicyReference": "RespondentPolicy",
           "OrgPolicyCaseAssignedRole": "[RespondentSolicitor]"
@@ -34,12 +32,10 @@
           "ApprovalStatus": null,
           "RequestTimestamp": null,
           "OrganisationToAdd": {
-            "OrganisationID": null,
-            "OrganisationName": null
+            "OrganisationID": null
           },
           "OrganisationToRemove": {
-            "OrganisationID": null,
-            "OrganisationName": null
+            "OrganisationID": null
           },
           "ApprovalRejectionTimestamp": null
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[ACA-68](https://tools.hmcts.net/jira/browse/ACA-68) _"3.3.6 NoCRequest API"_
[RDM-9893](https://tools.hmcts.net/jira/browse/RDM-9893) _"Organisation base type incorrectly contains a 'Name' Field"_

### Change description ###

Update the callback stub that simulates an approved NOC request that has been processed by `CheckForNoCApproval` and `ApplyNoCDecision`.   i.e. update OrganisationName references in preparation for:
* RDM-9893 - Remove OrganisationName references hmcts/aac-manage-case-assignment#136

This test stub should no longer be required once these APIs are ready.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
