### PR TITLE
RDM-10920 Stub GET /am/role-assignments/actors/{actorId}

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/ccd/test/stubs/service/config/WireMockServerConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/test/stubs/service/config/WireMockServerConfig.java
@@ -49,7 +49,9 @@ public class WireMockServerConfig {
                 .dynamicPort()
                 .usingFilesUnderDirectory(mappingsPath)
                 .extensions("uk.gov.hmcts.reform.ccd.test.stubs.service.wiremock.extension"
-                                + ".DynamicCaseDataResponseTransformer");
+                                + ".DynamicCaseDataResponseTransformer",
+                            "uk.gov.hmcts.reform.ccd.test.stubs.service.wiremock.extension"
+                                + ".DynamicRoleAssignmentsResponseTransformer");
         } else {
             LOG.info("using classpath resources to resolve mappings");
             return options()
@@ -57,7 +59,9 @@ public class WireMockServerConfig {
                 .dynamicPort()
                 .usingFilesUnderClasspath(mappingsPath)
                 .extensions("uk.gov.hmcts.reform.ccd.test.stubs.service.wiremock.extension"
-                                + ".DynamicCaseDataResponseTransformer");
+                                + ".DynamicCaseDataResponseTransformer",
+                            "uk.gov.hmcts.reform.ccd.test.stubs.service.wiremock.extension"
+                                + ".DynamicRoleAssignmentsResponseTransformer");
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/ccd/test/stubs/service/wiremock/extension/DynamicRoleAssignmentsResponseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/test/stubs/service/wiremock/extension/DynamicRoleAssignmentsResponseTransformer.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.ccd.test.stubs.service.wiremock.extension;
+
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.http.Response;
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * Retrieves userId from the url and replaces {{userId}} placeholder with its value
+ */
+public class DynamicRoleAssignmentsResponseTransformer extends AbstractDynamicResponseTransformer {
+
+    @VisibleForTesting
+    static final String DYNAMIC_ROLE_ASSIGNMENTS_RESPONSE_TRANSFORMER = "dynamic-role-assignments-response-transformer";
+
+    private static final Logger LOG = LoggerFactory.getLogger(DynamicRoleAssignmentsResponseTransformer.class);
+    private static final String USER_ID_PLACEHOLDER = "{{userId}}";
+    public static final String GET_ROLE_ASSIGNMENTS_URL = "/am/role-assignments/actors/";
+
+    @Override
+    protected String dynamiseResponse(Request request, Response response, Parameters parameters) {
+        if (request.getMethod().equals(RequestMethod.GET) && request.getUrl().contains(GET_ROLE_ASSIGNMENTS_URL)) {
+            LOG.info("Adding dynamic userId to response for request: {}", request.getUrl());
+            String userId = request.getUrl().substring(GET_ROLE_ASSIGNMENTS_URL.length());
+            LOG.info("Extracted userId path parameter: {}", userId);
+
+            return response.getBodyAsString().replace(USER_ID_PLACEHOLDER, userId);
+        } else {
+            return response.getBodyAsString();
+        }
+    }
+
+    @Override
+    public String getName() {
+        return DYNAMIC_ROLE_ASSIGNMENTS_RESPONSE_TRANSFORMER;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/ccd/test/stubs/service/wiremock/extension/DynamicRoleAssignmentsResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/test/stubs/service/wiremock/extension/DynamicRoleAssignmentsResponseTransformerTest.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.ccd.test.stubs.service.wiremock.extension;
+
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.http.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.ccd.test.stubs.service.wiremock.extension.DynamicRoleAssignmentsResponseTransformer.GET_ROLE_ASSIGNMENTS_URL;
+
+class DynamicRoleAssignmentsResponseTransformerTest {
+
+    public static final String USER_ID = "cc828f53-05cb-4534-b64f-1dfe30748b6c";
+    private final DynamicRoleAssignmentsResponseTransformer transformer =
+        new DynamicRoleAssignmentsResponseTransformer();
+
+    @Test
+    @DisplayName("Should add url userId to response")
+    void shouldAddUrlUserIdToResponse() {
+        Request request = mock(Request.class);
+        when(request.getMethod()).thenReturn(RequestMethod.GET);
+        when(request.getUrl()).thenReturn(GET_ROLE_ASSIGNMENTS_URL + USER_ID);
+        Response response = Response.response().body("{\"actorId\" : \"{{userId}}\"}").build();
+
+        Response result = transformer.transform(request, response, null, null);
+        assertThat(result.getBodyAsString(), is("{\"actorId\" : \"" + USER_ID + "\"}"));
+    }
+
+}

--- a/wiremock/mappings/roleassignmentservice/get_role_assignments.json
+++ b/wiremock/mappings/roleassignmentservice/get_role_assignments.json
@@ -1,0 +1,39 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/am/role-assignments/actors/.*"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "roleAssignmentResponse": [
+        {
+          "id": "4d96923f-891a-4cb1-863e-9bec44d1689d",
+          "actorIdType": "IDAM",
+          "actorId": "{{userId}}",
+          "roleType": "ORGANISATION",
+          "roleName": "judge",
+          "classification": "PUBLIC",
+          "grantType": "STANDARD",
+          "roleCategory": "JUDICIAL",
+          "readOnly": false,
+          "beginTime": "2021-01-01T00:00:00Z",
+          "endTime": "2223-01-01T00:00:00Z",
+          "created": "2020-12-23T06:37:58.096065Z",
+          "attributes": {
+            "contractType": "SALARIED",
+            "jurisdiction": "divorce",
+            "region": "south-east"
+          },
+          "authorisations": []
+        }
+      ]
+    },
+    "transformers": [
+      "dynamic-role-assignments-response-transformer"
+    ]
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-10920


### Change description ###
Stub for a new endpoint: GET /am/role-assignments/actors/{actorId}
It takes the actorId and puts it in the {{userId}} placeholder in the response body.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
