### PR TITLE
CCD-1322: Updated CVE suppression dates

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2021-06-25">
+  <suppress until="2021-07-25">
     <notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security (any version), see
       https://pivotal.io/security/cve-2018-1258
     </notes>
     <cve>CVE-2018-1258</cve>
   </suppress>
 
-  <suppress until="2021-06-25">
+  <suppress until="2021-07-25">
    <notes>WireMock 2.27.2 JRE 8 embeds jquery-3.4.1.min.js
      https://github.com/tomakehurst/wiremock/issues/1417
    </notes>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1322 (https://tools.hmcts.net/jira/browse/CCD-1322)


### Change description ###
Updated CVE suppression dates in dependency-check-suppressions.xml to
25/07/2021


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
