### PR TITLE
Resolve CVE-2021-28170

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,8 @@ dependencies {
   compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.10.3'
   compile "com.fasterxml.jackson.core:jackson-databind:2.11.1"
 
+  // CVE-2021-28170
+  compile group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1'
 
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,7 +2,7 @@
 <suppressions
 	xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-	<suppress until="2021-08-25">
+	<suppress until="2021-09-25">
 		<notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
 			(any version), see
 			https://pivotal.io/security/cve-2018-1258

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -10,11 +10,4 @@
 		<cve>CVE-2018-1258</cve>
 	</suppress>
 
-	<suppress until="2021-08-25">
-		<notes>In the Jakarta Expression Language implementation 3.0.3 and earlier, 
-		a bug in the ELParserTokenManager enables invalid EL expressions to be evaluated as if they were valid.
-		</notes>
-		<cve>CVE-2021-28170</cve>
-	</suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1861 (https://tools.hmcts.net/jira/browse/CCD-1861)


### Change description ###
- Resolved vulnerability in use of Jakarta EL version 3.0.3 by adding
dependency on version 4.0.1 to build.gradle file.
- Removed corresponding suppression from
dependency-check-suppressions.xml.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
