### PR TITLE
CCD-2115: Address CVE-2021-42340

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ repositories {
 
 ext {
   groovyVersion = '3.0.7'
-  tomcatVersion = '9.0.50!!'
+  tomcatVersion = '9.0.54!!'
   jettyVersion = '9.4.43.v20210629'
 }
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -10,9 +10,4 @@
 		<cve>CVE-2018-1258</cve>
 	</suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting Tomcat temporarily until it can be addressed</notes>
-    <cve>CVE-2021-42340</cve>
-  </suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2115 (https://tools.hmcts.net/jira/browse/CCD-2115)


### Change description ###
- Updated build.gradle. Set value of tomcatVersion property to 9.0.54 to resolve CVE-2021-42340.
- Removed suppression of CVE-2021-42340 from dependency-check-suppressions.xml.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
