### PR TITLE
CCD-2141: Address CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
   jettyVersion = '9.4.43.v20210629'
 }
 
-ext['spring-framework.version'] = '5.3.7'
+ext['spring-framework.version'] = '5.3.12'
 ext['spring-security.version'] = '5.4.5'
 
 // it is important to specify logback classic and core packages explicitly as libraries like spring boot

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -10,9 +10,4 @@
 		<cve>CVE-2018-1258</cve>
 	</suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Temp suppression to unblock pipeline.</notes>
-    <cve>CVE-2021-22096</cve>
-  </suppress>
-  
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2141 (https://tools.hmcts.net/jira/browse/CCD-2141)


### Change description ###
- Updated build.gradle. Set value of override of spring-framework.version property to 5.3.12 to address CVE-2021-22096.
- Removed temporary suppression of CVE-2021-22096 from dependency-check-suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
