### PR TITLE
Making callback name more generic

### DIFF
--- a/wiremock/mappings/ccd/callback_unmodified.json
+++ b/wiremock/mappings/ccd/callback_unmodified.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "POST",
-    "urlPath": "/callback_about_to_start_ttl_unmodified"
+    "urlPath": "/callback_unmodified"
   },
   "response": {
     "status": 200,


### PR DESCRIPTION
### Change description ###
Changed the name of the callback 'callback_about_to_start_ttl_unmodified' to 'callback_unmodified', so this can be reused in various requests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
