### PR TITLE
CCD-2231: Updated CVE suppression dates

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,7 +2,7 @@
 <suppressions
 	xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-	<suppress until="2021-12-25">
+	<suppress until="2022-01-25">
 		<notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
 			(any version), see
 			https://pivotal.io/security/cve-2018-1258


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2231 (https://tools.hmcts.net/jira/browse/CCD-2231)


### Change description ###
Changed CVE suppression dates in dependency-check-suppressions.xml to 2022-01-25.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
