### PR TITLE
CCD-2378: Re-enable Fortify scan

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -12,9 +12,8 @@ def product = "ccd"
 def component = "ccd-test-stubs-service"
 
 withNightlyPipeline(type, product, component) {
-  // Temporarily disable fortify scan stage until fortify access re-enabled
-  //enableFortifyScan();
-  //after('fortify-scan') {
-  //  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
-  //}
+  enableFortifyScan();
+  after('fortify-scan') {
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -281,4 +281,5 @@ task fortifyScan(type: JavaExec)  {
   main = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
   classpath += sourceSets.test.runtimeClasspath
   jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
+  ignoreExitValue = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -281,5 +281,6 @@ task fortifyScan(type: JavaExec)  {
   main = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
   classpath += sourceSets.test.runtimeClasspath
   jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
-  ignoreExitValue = true
+  // Uncomment the line below to prevent the build from failing if the Fortify scan detects issues
+  //ignoreExitValue = true
 }

--- a/config/fortify-client.properties
+++ b/config/fortify-client.properties
@@ -1,2 +1,2 @@
-fortify.client.releaseId=73835
+fortify.client.releaseId=91371
 fortify.exclude.pattern=*.jar|*.zip|*.tar|/build|/.gradle|/.git|/node_modules|/dist


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2378 (https://tools.hmcts.net/jira/browse/CCD-2378)


### Change description ###
- Changed fortify release id in fortify-client.properties to new value provided by fortify support.  This should resolve the "The entitlementPreferenceType is not available" error in the Fortify Scan stage of the nightly build pipeline.
- Uncommented Fortify scan steps in Jenkinsfile_nightly to re-enable Fortify scan


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
