### PR TITLE
CVE-2022-29885: ccd-test-stubs-service fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ repositories {
 
 ext {
   groovyVersion = '3.0.7'
-  tomcatVersion = '9.0.58!!'
+  tomcatVersion = '9.0.63!!'
   jettyVersion = '9.4.43.v20210629'
 }
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -16,6 +16,7 @@
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
     <vulnerabilityName>CVE-2022-22965</vulnerabilityName>
   </suppress>
+
   <suppress>
     <notes><![CDATA[
    file name: spring-core-5.3.18.jar
@@ -24,22 +25,7 @@
     <cve>CVE-2022-22968</cve>
   </suppress>
 
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-core-9.0.58.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-    <cve>CVE-2022-29885</cve>
-  </suppress>
-
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-websocket-9.0.58.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
-    <cve>CVE-2022-29885</cve>
-  </suppress>
-  <suppress>
+  <suppress until="2022-06-25">
     <notes><![CDATA[
    file name: spring-core-5.3.19.jar
    ]]></notes>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -25,7 +25,7 @@
     <cve>CVE-2022-22968</cve>
   </suppress>
 
-  <suppress until="2022-06-25">
+  <suppress>
     <notes><![CDATA[
    file name: spring-core-5.3.19.jar
    ]]></notes>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3269

Upgrading tomcat version to 9.0.63.
The documentation of Apache Tomcat 10.1.0-M1 to 10.1.0-M14, 10.0.0-M1 to 10.0.20, 9.0.13 to 9.0.62 and 8.5.38 to 8.5.78 for the EncryptInterceptor incorrectly stated it enabled Tomcat clustering to run over an untrusted network. This was not correct.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
