### PR TITLE
Update dependency-check-suppressions.xml added temporary suppression for CVE-2022-34305

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -33,6 +33,16 @@
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
     <cve>CVE-2022-22971</cve>
   </suppress>
+  
+  <suppress>
+   <notes><![CDATA[
+    file name: tomcat-embed-core-9.0.63.jar
+    ]]>
+    https://tools.hmcts.net/jira/browse/CCD-3431
+   </notes>
+   <cve>CVE-2022-34305</cve>
+  </suppress>
+  
   <!--End of temporary suppression section -->
 
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -12,37 +12,18 @@
     <cve>CVE-2016-1000027</cve>
   </suppress>
   <!--End of false positives section -->
-
+  
   <!--Please add all the temporary suppression under the below section -->
   <suppress>
-    <notes><![CDATA[
-       file name: spring-core-5.3.19.jar
-       ]]>
-      https://tools.hmcts.net/jira/browse/CCD-3292
+    <notes>Temporary Suppression
+      CVE-2022-22970  refer https://tools.hmcts.net/jira/browse/CCD-3292
+      CVE-2022-22971  refer https://tools.hmcts.net/jira/browse/CCD-3292
+      CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3431
     </notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
     <cve>CVE-2022-22970</cve>
-  </suppress>
-
-  <suppress>
-    <notes><![CDATA[
-      file name: spring-core-5.3.19.jar
-      ]]>
-      https://tools.hmcts.net/jira/browse/CCD-3292
-    </notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
     <cve>CVE-2022-22971</cve>
+    <cve>CVE-2022-34305</cve>
   </suppress>
-  
-  <suppress>
-   <notes><![CDATA[
-    file name: tomcat-embed-core-9.0.63.jar
-    ]]>
-    https://tools.hmcts.net/jira/browse/CCD-3431
-   </notes>
-   <cve>CVE-2022-34305</cve>
-  </suppress>
-  
   <!--End of temporary suppression section -->
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3431

### Change description ###

Update dependency-check-suppressions.xml added temporary suppression for CVE-2022-34305

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
