### PR TITLE
HMAN-311 - Add new HMC stubs

### DIFF
--- a/charts/ccd-test-stubs-service/Chart.yaml
+++ b/charts/ccd-test-stubs-service/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for ccd-test-stubs-service App
 name: ccd-test-stubs-service
 home: https://github.com/hmcts/ccd-test-stubs-service
-version: 1.2.4
+version: 1.2.5
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/src/main/java/uk/gov/hmcts/reform/ccd/test/stubs/service/config/WireMockServerConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/test/stubs/service/config/WireMockServerConfig.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.ccd.test.stubs.service.config;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,20 +48,23 @@ public class WireMockServerConfig {
         var extension1 = WIREMOCK_EXTENSION_PREFIX + ".DynamicCaseDataResponseTransformer";
         var extension2 = WIREMOCK_EXTENSION_PREFIX + ".DynamicRoleAssignmentsResponseTransformer";
         var extension3 = WIREMOCK_EXTENSION_PREFIX + ".DynamicCaseCaseDataResponseTransformer";
+        var responseTemplating = new ResponseTemplateTransformer(true);
 
         if (mappingDirectory.isDirectory()) {
             return options()
                 .dynamicHttpsPort()
                 .dynamicPort()
                 .usingFilesUnderDirectory(mappingsPath)
-                .extensions(extension1, extension2, extension3);
+                .extensions(extension1, extension2, extension3)
+                .extensions(responseTemplating);
         } else {
             LOG.info("using classpath resources to resolve mappings");
             return options()
                 .dynamicHttpsPort()
                 .dynamicPort()
                 .usingFilesUnderClasspath(mappingsPath)
-                .extensions(extension1, extension2, extension3);
+                .extensions(extension1, extension2, extension3)
+                .extensions(responseTemplating);
         }
     }
 }

--- a/wiremock/mappings/hmc/ccd/getCcdCaseById.json
+++ b/wiremock/mappings/hmc/ccd/getCcdCaseById.json
@@ -1,0 +1,103 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/cases/(\\d{16})"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type" : "application/vnd.uk.gov.hmcts.ccd-data-store-api.case.v2+json;charset=UTF-8"
+    },
+    "jsonBody": {
+      "data": {
+        "_links" : {
+          "self" : {
+            "href" : "https://ccd-data-store-api-staging.service.core-compute-aat.internal/cases/{{request.path.[1]}}"
+          }
+        },
+        "id" : "{{request.path.[1]}}",
+        "jurisdiction" : "AUTOTEST1",
+        "case_type" : "AAT_AUTH_15",
+        "created_on" : "2022-07-01T15:08:58.566524",
+        "last_modified_on" : "2022-07-01T15:08:58.567438",
+        "last_state_modified_on" : "2022-07-01T15:08:58.566524",
+        "state" : "TODO",
+        "security_classification" : "PUBLIC",
+        "data" : {
+          "MoneyGBPField" : "4200",
+          "FixedListField" : "VALUE3",
+          "AddressUKField" : {
+            "County" : "Greater London",
+            "Country" : "UK",
+            "PostCode" : "SW1H 9AJ",
+            "PostTown" : "Westminster",
+            "AddressLine1" : "102 Petty France",
+            "AddressLine2" : "CCD",
+            "AddressLine3" : "c/o HMCTS Reform"
+          },
+          "ComplexField" : {
+            "ComplexTextField" : "Nested text",
+            "ComplexFixedListField" : "VALUE2"
+          },
+          "DateTimeField" : "1988-07-07T22:20:00",
+          "PhoneUKField" : "07123456789",
+          "NumberField" : "164528",
+          "MultiSelectListField" : [ "OPTION2", "OPTION4" ],
+          "YesOrNoField" : "Yes",
+          "EmailField" : "ccd@hmcts.net",
+          "TextField" : "Some Text",
+          "DateField" : "2017-02-13",
+          "TextAreaField" : "Line1\nLine2",
+          "CollectionField" : [ {
+            "id" : "CollectionField1",
+            "value" : "Alias 1"
+          }, {
+            "id" : "CollectionField2",
+            "value" : "Alias 2"
+          } ]
+        },
+        "data_classification" : {
+          "MoneyGBPField" : "PUBLIC",
+          "FixedListField" : "PUBLIC",
+          "AddressUKField" : {
+            "value" : {
+              "County" : "PUBLIC",
+              "Country" : "PUBLIC",
+              "PostCode" : "PUBLIC",
+              "PostTown" : "PUBLIC",
+              "AddressLine1" : "PUBLIC",
+              "AddressLine2" : "PUBLIC",
+              "AddressLine3" : "PUBLIC"
+            },
+            "classification" : "PUBLIC"
+          },
+          "DateTimeField" : "PUBLIC",
+          "PhoneUKField" : "PUBLIC",
+          "NumberField" : "PUBLIC",
+          "MultiSelectListField" : "PUBLIC",
+          "YesOrNoField" : "PUBLIC",
+          "EmailField" : "PUBLIC",
+          "TextField" : "PUBLIC",
+          "DateField" : "PUBLIC",
+          "TextAreaField" : "PUBLIC",
+          "CollectionField" : {
+            "value" : [ {
+              "id" : "CollectionField1",
+              "classification" : "PUBLIC"
+            }, {
+              "id" : "CollectionField2",
+              "classification" : "PUBLIC"
+            } ],
+            "classification" : "PUBLIC"
+          }
+        },
+        "after_submit_callback_response" : null,
+        "callback_response_status_code" : null,
+        "callback_response_status" : null,
+        "delete_draft_response_status_code" : null,
+        "delete_draft_response_status" : null
+      }
+      },
+    "transformers": ["response-template"]
+    }
+}

--- a/wiremock/mappings/hmc/ccd/getCcdCaseById.json
+++ b/wiremock/mappings/hmc/ccd/getCcdCaseById.json
@@ -9,94 +9,30 @@
       "Content-Type" : "application/vnd.uk.gov.hmcts.ccd-data-store-api.case.v2+json;charset=UTF-8"
     },
     "jsonBody": {
-      "data": {
-        "_links" : {
-          "self" : {
-            "href" : "https://ccd-data-store-api-staging.service.core-compute-aat.internal/cases/{{request.path.[1]}}"
-          }
-        },
-        "id" : "{{request.path.[1]}}",
-        "jurisdiction" : "AUTOTEST1",
-        "case_type" : "AAT_AUTH_15",
-        "created_on" : "2022-07-01T15:08:58.566524",
-        "last_modified_on" : "2022-07-01T15:08:58.567438",
-        "last_state_modified_on" : "2022-07-01T15:08:58.566524",
-        "state" : "TODO",
-        "security_classification" : "PUBLIC",
-        "data" : {
-          "MoneyGBPField" : "4200",
-          "FixedListField" : "VALUE3",
-          "AddressUKField" : {
-            "County" : "Greater London",
-            "Country" : "UK",
-            "PostCode" : "SW1H 9AJ",
-            "PostTown" : "Westminster",
-            "AddressLine1" : "102 Petty France",
-            "AddressLine2" : "CCD",
-            "AddressLine3" : "c/o HMCTS Reform"
-          },
-          "ComplexField" : {
-            "ComplexTextField" : "Nested text",
-            "ComplexFixedListField" : "VALUE2"
-          },
-          "DateTimeField" : "1988-07-07T22:20:00",
-          "PhoneUKField" : "07123456789",
-          "NumberField" : "164528",
-          "MultiSelectListField" : [ "OPTION2", "OPTION4" ],
-          "YesOrNoField" : "Yes",
-          "EmailField" : "ccd@hmcts.net",
-          "TextField" : "Some Text",
-          "DateField" : "2017-02-13",
-          "TextAreaField" : "Line1\nLine2",
-          "CollectionField" : [ {
-            "id" : "CollectionField1",
-            "value" : "Alias 1"
-          }, {
-            "id" : "CollectionField2",
-            "value" : "Alias 2"
-          } ]
-        },
-        "data_classification" : {
-          "MoneyGBPField" : "PUBLIC",
-          "FixedListField" : "PUBLIC",
-          "AddressUKField" : {
-            "value" : {
-              "County" : "PUBLIC",
-              "Country" : "PUBLIC",
-              "PostCode" : "PUBLIC",
-              "PostTown" : "PUBLIC",
-              "AddressLine1" : "PUBLIC",
-              "AddressLine2" : "PUBLIC",
-              "AddressLine3" : "PUBLIC"
-            },
-            "classification" : "PUBLIC"
-          },
-          "DateTimeField" : "PUBLIC",
-          "PhoneUKField" : "PUBLIC",
-          "NumberField" : "PUBLIC",
-          "MultiSelectListField" : "PUBLIC",
-          "YesOrNoField" : "PUBLIC",
-          "EmailField" : "PUBLIC",
-          "TextField" : "PUBLIC",
-          "DateField" : "PUBLIC",
-          "TextAreaField" : "PUBLIC",
-          "CollectionField" : {
-            "value" : [ {
-              "id" : "CollectionField1",
-              "classification" : "PUBLIC"
-            }, {
-              "id" : "CollectionField2",
-              "classification" : "PUBLIC"
-            } ],
-            "classification" : "PUBLIC"
-          }
-        },
-        "after_submit_callback_response" : null,
-        "callback_response_status_code" : null,
-        "callback_response_status" : null,
-        "delete_draft_response_status_code" : null,
-        "delete_draft_response_status" : null
-      }
+      "_links" : {
+        "self" : {
+          "href" : "https://ccd-data-store-api-staging.service.core-compute-aat.internal/cases/{{request.path.[1]}}"
+        }
+      },
+      "id" : "{{request.path.[1]}}",
+      "jurisdiction" : "BEFTA_MASTER",
+      "case_type" : "FT_CRUD",
+      "created_on" : "2022-07-01T15:08:58.566524",
+      "last_modified_on" : "2022-07-01T15:08:58.567438",
+      "last_state_modified_on" : "2022-07-01T15:08:58.566524",
+      "state" : "TODO",
+      "security_classification" : "PUBLIC",
+      "data" : {
+        "TextAreaField" : "Line1\nLine2"
+      },
+      "data_classification" : {
+        "TextAreaField" : "PUBLIC"
+      },
+      "after_submit_callback_response" : null,
+      "callback_response_status_code" : null,
+      "callback_response_status" : null,
+      "delete_draft_response_status_code" : null,
+      "delete_draft_response_status" : null
       },
     "transformers": ["response-template"]
     }

--- a/wiremock/mappings/hmc/hearing/amendRequestHearing.json
+++ b/wiremock/mappings/hmc/hearing/amendRequestHearing.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "PUT",
+    "urlPattern": "/hmi/hearings/([a-zA-Z0-9]{1,10})"
+  },
+  "response": {
+    "status": 202,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "response code": 202,
+      "description": "The request was amended successfully."
+    }
+  }
+}

--- a/wiremock/mappings/hmc/hearing/createRequestHearing.json
+++ b/wiremock/mappings/hmc/hearing/createRequestHearing.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/hmi/hearings"
+  },
+  "response": {
+    "status": 202,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "response code": 202,
+      "description": "The request was received successfully."
+    }
+  }
+}

--- a/wiremock/mappings/hmc/hearing/deleteRequestHearing.json
+++ b/wiremock/mappings/hmc/hearing/deleteRequestHearing.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "DELETE",
+    "urlPattern": "/hmi/hearings/([a-zA-Z0-9]{1,10})"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "response code": 200,
+      "description": "The request was deleted successfully."
+    }
+  }
+}

--- a/wiremock/mappings/hmc/linkedHearingGroup/createLinkedHearingGroup.json
+++ b/wiremock/mappings/hmc/linkedHearingGroup/createLinkedHearingGroup.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPattern": "/hmi/resources/linked-hearing-group/(\\d{1,})"
+  },
+  "response": {
+    "status": 201,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "hearingGroupRequestId": 12345
+    }
+  }
+}

--- a/wiremock/mappings/hmc/linkedHearingGroup/deleteLinkedHearingGroup.json
+++ b/wiremock/mappings/hmc/linkedHearingGroup/deleteLinkedHearingGroup.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "DELETE",
+    "urlPattern": "/hmi/resources/linked-hearing-group/(\\d{1,})"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {}
+  }
+}

--- a/wiremock/mappings/hmc/linkedHearingGroup/updateLinkedHearingGroup.json
+++ b/wiremock/mappings/hmc/linkedHearingGroup/updateLinkedHearingGroup.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "PUT",
+    "urlPattern": "/hmi/resources/linked-hearing-group/(\\d{1,})"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {}
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-311

### Change description ###
Mock calls to HMI/FH/ListAssist

A test stub will need to be created to be able to mock response from FH which is an external team call 
Endpoints are
[Create, Delete, Amend Hearing](https://github.com/hmcts/hmc-hmi-outbound-adapter/blob/master/src/main/java/uk/gov/hmcts/reform/hmc/client/futurehearing/HearingManagementInterfaceApiClient.java)
[Create, Update, Delete Linked group](https://github.com/hmcts/hmc-cft-hearing-service/blob/master/src/main/java/uk/gov/hmcts/reform/hmc/client/futurehearing/HearingManagementInterfaceApiClient.java)
[Generate Token](https://github.com/hmcts/hmc-cft-hearing-service/blob/master/src/main/java/uk/gov/hmcts/reform/hmc/client/futurehearing/ActiveDirectoryApiClient.java)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
