### PR TITLE
CCD-3449: CVE-2022-33915 ccd-test-stubs-service

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -7,24 +7,24 @@
     <notes>False Positives
       CVE-2018-1258 refer https://tools.hmcts.net/jira/browse/CCD-761
       CVE-2016-1000027 refer https://tools.hmcts.net/jira/browse/CCD-3252
+      CVE-2022-33915 refer https://tools.hmcts.net/jira/browse/CCD-3449
     </notes>
     <cve>CVE-2018-1258</cve>
     <cve>CVE-2016-1000027</cve>
+    <cve>CVE-2022-33915</cve>
   </suppress>
   <!--End of false positives section -->
-  
+
   <!--Please add all the temporary suppression under the below section -->
   <suppress>
     <notes>Temporary Suppression
       CVE-2022-22970  refer https://tools.hmcts.net/jira/browse/CCD-3292
       CVE-2022-22971  refer https://tools.hmcts.net/jira/browse/CCD-3292
       CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3431
-      CVE-2022-33915. refer https://tools.hmcts.net/jira/browse/CCD-3449
     </notes>
     <cve>CVE-2022-22970</cve>
     <cve>CVE-2022-22971</cve>
     <cve>CVE-2022-34305</cve>
-    <cve>CVE-2022-33915</cve>
   </suppress>
   <!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-3439

### Change description ###
False positive.   CVE-2022-33915 (cpe;2.3;a;apache;log4j) only impacts AWS Log4j hotpatch , and not general Log4j build.   See Jira ticket.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```