### PR TITLE
CCD-3431 CVE-2022-34305 suppression moved from temp to false positive

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -8,10 +8,12 @@
       CVE-2018-1258 refer https://tools.hmcts.net/jira/browse/CCD-761
       CVE-2016-1000027 refer https://tools.hmcts.net/jira/browse/CCD-3252
       CVE-2022-33915 refer https://tools.hmcts.net/jira/browse/CCD-3449
+      CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3431
     </notes>
     <cve>CVE-2018-1258</cve>
     <cve>CVE-2016-1000027</cve>
     <cve>CVE-2022-33915</cve>
+    <cve>CVE-2022-34305</cve>
   </suppress>
   <!--End of false positives section -->
 
@@ -20,13 +22,11 @@
     <notes>Temporary Suppression
       CVE-2022-22970  refer https://tools.hmcts.net/jira/browse/CCD-3292
       CVE-2022-22971  refer https://tools.hmcts.net/jira/browse/CCD-3292
-      CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3431
       CVE-2022-22978  refer https://tools.hmcts.net/jira/browse/CCD-3513 spring_security:5.4.5
       CVE-2022-31569  refer https://tools.hmcts.net/jira/browse/CCD-3536
     </notes>
     <cve>CVE-2022-22970</cve>
     <cve>CVE-2022-22971</cve>
-    <cve>CVE-2022-34305</cve>
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2022-31569</cve>
   </suppress>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3431
CVE-2022-34305 suppression moved from temp to False Positive

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
