### PR TITLE
HMAN-368 - Add next hearing date callbacks

### DIFF
--- a/wiremock/mappings/ccd/callback_nextHearingDate.json
+++ b/wiremock/mappings/ccd/callback_nextHearingDate.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/callback_nextHearingDate"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "data": {
+        "NextHearingDetails": {
+          "hearingId": "123456",
+          "hearingDateTime": "2030-04-23T19:24:32.511Z"
+        }
+      }
+    }
+  }
+}

--- a/wiremock/mappings/ccd/callback_nextHearingDate.json
+++ b/wiremock/mappings/ccd/callback_nextHearingDate.json
@@ -10,9 +10,9 @@
     },
     "jsonBody": {
       "data": {
-        "NextHearingDetails": {
-          "hearingId": "123456",
-          "hearingDateTime": "2030-04-23T19:24:32.511Z"
+        "nextHearingDetails": {
+          "hearingID": 123456,
+          "hearingDateTime": "2030-04-23T10:00:00.000"
         }
       }
     }

--- a/wiremock/mappings/ccd/callback_nextHearingDateIsInPast.json
+++ b/wiremock/mappings/ccd/callback_nextHearingDateIsInPast.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/callback_nextHearingDateIsInPast"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "data": {
+        "NextHearingDetails": {
+          "hearingId": "123456",
+          "hearingDateTime": "2020-04-23T19:24:32.511Z"
+        }
+      }
+    }
+  }
+}

--- a/wiremock/mappings/ccd/callback_nextHearingDateIsInPast.json
+++ b/wiremock/mappings/ccd/callback_nextHearingDateIsInPast.json
@@ -10,9 +10,9 @@
     },
     "jsonBody": {
       "data": {
-        "NextHearingDetails": {
-          "hearingId": "123456",
-          "hearingDateTime": "2020-04-23T19:24:32.511Z"
+        "nextHearingDetails": {
+          "hearingID": 123456,
+          "hearingDateTime": "2020-04-23T10:00:00.000"
         }
       }
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [HMAN-368](https://tools.hmcts.net/jira/browse/HMAN-368) _"Ccd Def store definition changes"_

### Change description ###

Add next hearing date callbacks

> NB: these callbacks are referenced in hmcts/ccd-test-definitions#53 and used in FTAs:
> * hmcts/ccd-next-hearing-date-updater#38
> * hmcts/ccd-next-hearing-date-updater#53

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
