### PR TITLE
CCD-3431 CVE-2022-34305 tomcat upgrade, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ repositories {
 
 ext {
   groovyVersion = '3.0.7'
-  tomcatVersion = '9.0.63!!'
+  tomcatVersion = '9.0.65!!'
   jettyVersion = '9.4.48.v20220622'
 }
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -6,10 +6,8 @@
   <suppress>
     <notes>False Positives
       CVE-2016-1000027 refer https://tools.hmcts.net/jira/browse/CCD-3252
-      CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3431
     </notes>
     <cve>CVE-2016-1000027</cve>
-    <cve>CVE-2022-34305</cve>
   </suppress>
   <!--End of false positives section -->
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3431
 CVE-2022-34305 tomcat upgrade

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
