### PR TITLE
CCD-3658-CVE-2022-25857-fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ ext['spring-framework.version'] = '5.3.20'
 ext['spring-security.version'] = '5.4.7'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.13.2'
-ext['snakeyaml.version'] = '1.31'
+ext['snakeyaml.version'] = '1.32'
 
 // it is important to specify logback classic and core packages explicitly as libraries like spring boot
 // enforces it's own (older) version which is not recommended.

--- a/build.gradle
+++ b/build.gradle
@@ -144,6 +144,7 @@ ext['spring-framework.version'] = '5.3.20'
 ext['spring-security.version'] = '5.4.7'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.13.2'
+ext['snakeyaml.version'] = '1.31'
 
 // it is important to specify logback classic and core packages explicitly as libraries like spring boot
 // enforces it's own (older) version which is not recommended.

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -14,10 +14,7 @@
   <!--End of false positives section -->
 
   <!--Please add all the temporary suppression under the below section -->
-  <suppress>
-    <notes>Temporary Suppression
-    </notes>
-  </suppress>
+
   <!--End of temporary suppression section -->
 
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -16,9 +16,7 @@
   <!--Please add all the temporary suppression under the below section -->
   <suppress>
     <notes>Temporary Suppression
-      CVE-2022-25857 refer https://tools.hmcts.net/jira/browse/CCD-3658
     </notes>
-    <cve>CVE-2022-25857</cve>
   </suppress>
   <!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3658

### Change description ###

Removed suppression for CVE-2022-25857 and updated build.gradle with ext['snakeyaml.version'] = '1.31'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
