### PR TITLE
HMAN-342 add extra Next Hearing Date callbacks

### DIFF
--- a/wiremock/mappings/ccd/callback_nextHearingDate.json
+++ b/wiremock/mappings/ccd/callback_nextHearingDate.json
@@ -15,6 +15,7 @@
           "hearingDateTime": "{{now offset='8 years' format='yyyy'}}-04-23T10:00:00.000"
         }
       }
-    }
+    },
+    "transformers": ["response-template"]
   }
 }

--- a/wiremock/mappings/ccd/callback_nextHearingDateClear.json
+++ b/wiremock/mappings/ccd/callback_nextHearingDateClear.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "POST",
-    "urlPath": "/callback_nextHearingDate"
+    "urlPath": "/callback_nextHearingDateClear"
   },
   "response": {
     "status": 200,
@@ -11,8 +11,8 @@
     "jsonBody": {
       "data": {
         "nextHearingDetails": {
-          "hearingID": 123456,
-          "hearingDateTime": "{{now offset='8 years' format='yyyy'}}-04-23T10:00:00.000"
+          "hearingID": null,
+          "hearingDateTime": null
         }
       }
     }

--- a/wiremock/mappings/ccd/callback_nextHearingDateIsNull.json
+++ b/wiremock/mappings/ccd/callback_nextHearingDateIsNull.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "POST",
-    "urlPath": "/callback_nextHearingDate"
+    "urlPath": "/callback_nextHearingDateIsNull"
   },
   "response": {
     "status": 200,
@@ -12,7 +12,7 @@
       "data": {
         "nextHearingDetails": {
           "hearingID": 123456,
-          "hearingDateTime": "{{now offset='8 years' format='yyyy'}}-04-23T10:00:00.000"
+          "hearingDateTime": null
         }
       }
     }

--- a/wiremock/mappings/ccd/callback_nextHearingIdIsNull.json
+++ b/wiremock/mappings/ccd/callback_nextHearingIdIsNull.json
@@ -15,6 +15,7 @@
           "hearingDateTime": "{{now offset='8 years' format='yyyy'}}-04-23T10:00:00.000"
         }
       }
-    }
+    },
+    "transformers": ["response-template"]
   }
 }

--- a/wiremock/mappings/ccd/callback_nextHearingIdIsNull.json
+++ b/wiremock/mappings/ccd/callback_nextHearingIdIsNull.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "POST",
-    "urlPath": "/callback_nextHearingDate"
+    "urlPath": "/callback_nextHearingIdIsNull"
   },
   "response": {
     "status": 200,
@@ -11,7 +11,7 @@
     "jsonBody": {
       "data": {
         "nextHearingDetails": {
-          "hearingID": 123456,
+          "hearingID": null,
           "hearingDateTime": "{{now offset='8 years' format='yyyy'}}-04-23T10:00:00.000"
         }
       }


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [HMAN-342](https://tools.hmcts.net/jira/browse/HMAN-342) _"BEFTA for NextHearingDate"_
   * [HMAN-381](https://tools.hmcts.net/jira/browse/HMAN-381) _"FTAs for CSV Processing"_ (sub-task)
   * [HMAN-382](https://tools.hmcts.net/jira/browse/HMAN-382) _"FTAs for Elastic Search processing"_ (sub-task)

### Change description ###

Extra callbacks to support extra functional test automation scripts in hmcts/ccd-next-hearing-date-updater#94

> Test PRs in main repos: 
> * hmcts/ccd-definition-store-api#1315
> * hmcts/ccd-data-store-api#2154

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
