### PR TITLE
CCD-4163 Bump rse-gradle-java-plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'org.springframework.boot' version '2.4.4'
   id 'com.github.ben-manes.versions' version '0.20.0'
   id 'org.sonarqube' version '2.6.2'
-  id 'uk.gov.hmcts.java' version '0.12.28'
+  id 'uk.gov.hmcts.java' version '0.12.37'
 }
 
 group = 'uk.gov.hmcts.reform.ccd'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4163

### Change description ###
Bump rse-gradle-java-plugin to 0.12.37

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

