### PR TITLE
CCD-4283: Bump gradle-java-plugin to 0.12.40

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'org.springframework.boot' version '2.4.4'
   id 'com.github.ben-manes.versions' version '0.20.0'
   id 'org.sonarqube' version '2.6.2'
-  id 'uk.gov.hmcts.java' version '0.12.37'
+  id 'uk.gov.hmcts.java' version '0.12.40'
 }
 
 group = 'uk.gov.hmcts.reform.ccd'


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-4283

### Change description ###
Bump gradle-java-plugin to 0.12.40

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```