### PR TITLE
CCD-4476 : changed reform-api-docs to cnp-api-docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
   - $HOME/.gradle/wrapper/
 
 before_install:
-#  - curl https://raw.githubusercontent.com/hmcts/reform-api-docs/master/bin/publish-swagger-docs.sh > publish-swagger-docs.sh
+#  - curl https://raw.githubusercontent.com/hmcts/cnp-api-docs/master/bin/publish-swagger-docs.sh > publish-swagger-docs.sh
 
 script:
   - ./gradlew test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4476

### Change description ###

CCD-4476 : changed reform-api-docs to cnp-api-docs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
