### PR TITLE
CCD-4599 : Update build.gradle (Bump sonaqube version to 2.7)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
   id 'org.springframework.boot' version '2.4.4'
   id 'com.github.ben-manes.versions' version '0.20.0'
-  id 'org.sonarqube' version '2.6.2'
+  id 'org.sonarqube' version '2.7'
   id 'uk.gov.hmcts.java' version '0.12.40'
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4599

### Change description ###

CCD-4599 : Update build.gradle (Bump sonaqube version to 2.7), to fix broken downstream link to sonarcloud

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
