### PR TITLE
CCD-4739 : Fix Fix CVE-2023-20860, CVE-2023-20861, CVE-2023-20863 (bumped versions of gradle, springframework, springsecurity)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'application'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
-  id 'org.springframework.boot' version '2.7.11'
+  id 'org.springframework.boot' version '2.4.4'
   id 'com.github.ben-manes.versions' version '0.20.0'
   id 'org.sonarqube' version '2.7'
   id 'uk.gov.hmcts.java' version '0.12.40'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'application'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
-  id 'org.springframework.boot' version '2.4.4'
+  id 'org.springframework.boot' version '2.7.11'
   id 'com.github.ben-manes.versions' version '0.20.0'
   id 'org.sonarqube' version '2.7'
   id 'uk.gov.hmcts.java' version '0.12.40'
@@ -140,8 +140,8 @@ ext {
   jettyVersion = '9.4.48.v20220622'
 }
 
-ext['spring-framework.version'] = '5.3.20'
-ext['spring-security.version'] = '5.6.9'
+ext['spring-framework.version'] = '5.3.27'
+ext['spring-security.version'] = '5.7.8'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.14.1'
 ext['snakeyaml.version'] = '1.32'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -3,20 +3,14 @@
     <notes>Temporary Suppression
         CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
         CVE-2022-1471 refer https://tools.hmcts.net/jira/browse/CCD-4454
-    
-        CVE-2023-20861 refer [Ticket]
-        CVE-2023-20860 refer [Ticket]
-        CVE-2023-20863 refer [Ticket]
         CVE-2023-26048 refer [Ticket]
         CVE-2023-26049 refer [Ticket]
         CVE-2023-20873 refer [Ticket]
         CVE-2023-28709 refer [Ticket]
-        CVE-2023-20883 refer [Ticket]</notes>
+        CVE-2023-20883 refer [Ticket]
+    </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2022-1471</cve>
-    <cve>CVE-2023-20861</cve>
-    <cve>CVE-2023-20860</cve>
-    <cve>CVE-2023-20863</cve>
     <cve>CVE-2023-26048</cve>
     <cve>CVE-2023-26049</cve>
     <cve>CVE-2023-20873</cve>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4739

### Change description ###

CCD-4739 : Fix Fix CVE-2023-20860, CVE-2023-20861, CVE-2023-20863 (bumped versions of gradle, springframework, springsecurity)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
