### PR TITLE
Revert move to Caffeine caching

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,14 +8,11 @@
   "packageRules": [
     {
       "matchUpdateTypes": [
-        "minor",
-        "patch"
+        "minor", "patch"
       ],
       "groupName": "All patch-minor dependencies",
       "groupSlug": "All-minor-patch",
-      "addLabels": [
-        "Renovate All-minor-patch"
-      ],
+      "addLabels": ["Renovate All-minor-patch"],
       "automerge": false
     }
   ]

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
   id 'org.springframework.boot' version '2.4.4'
   id 'com.github.ben-manes.versions' version '0.20.0'
-  id 'org.sonarqube' version '4.4.0.3356'
+  id 'org.sonarqube' version '2.7'
   id 'uk.gov.hmcts.java' version '0.12.40'
 }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,11 +15,6 @@ management:
 spring:
   application:
     name: CCD Test Stubs Services
-  cloud:
-    discovery:
-      client:
-        composite-indicator:
-          enabled: false
 
 wiremock:
   server:
@@ -31,7 +26,7 @@ logging:
     root: INFO
     org.springframework.web: WARN
     com.github.tomakehurst: INFO
-    
+
 app:
   management-web-url: ${MANAGEMENT_WEB_URL:http://localhost:3451}
   secret-key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA


### PR DESCRIPTION
"CCD-4214 Remove discoveryComposite from health endpoint (#214)"

This reverts commit 1d5257b744da876c30ecd141fdcbb497b872bdee.

https://tools.hmcts.net/jira/browse/CCD-4214

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
