### PR TITLE
CCD-4970 : Fix CVE-2020-8908

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ ext['snakeyaml.version'] = '1.32'
 // enforces it's own (older) version which is not recommended.
 def versions = [
   junit           : '5.3.2',
-  reformLogging   : '5.1.9',
+  reformLogging   : '6.0.1',
   springBoot      : springBoot.class.package.implementationVersion,
   springfoxSwagger: '3.0.0',
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,7 @@ def versions = [
 dependencies {
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '3.0.1'
 
-  implementation group: 'com.google.guava', name: 'guava', version:'30.1-jre'
+  implementation group: 'com.google.guava', name: 'guava', version:'32.1.2-jre'
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 
   implementation "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}"

--- a/charts/ccd-test-stubs-service/Chart.yaml
+++ b/charts/ccd-test-stubs-service/Chart.yaml
@@ -3,11 +3,11 @@ appVersion: "1.0"
 description: A Helm chart for ccd-test-stubs-service App
 name: ccd-test-stubs-service
 home: https://github.com/hmcts/ccd-test-stubs-service
-version: 1.2.10
+version: 1.2.11
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET
 dependencies:
   - name: java
-    version: 4.0.13
+    version: 5.0.0
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -22,6 +22,7 @@
         CVE-2023-45648 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
         CVE-2023-5072 refer [Ticket]
+        CVE-2023-36478 refer [Ticket]
     </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2022-1471</cve>
@@ -43,5 +44,6 @@
     <cve>CVE-2023-45648</cve>
     <cve>CVE-2023-44487</cve>
     <cve>CVE-2023-5072</cve>
+    <cve>CVE-2023-36478</cve>
   </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -10,7 +10,6 @@
         CVE-2023-35116 refer [Ticket]
         CVE-2023-2976 refer [Ticket]
         CVE-2023-34034 refer [Ticket]
-        CVE-2020-8908 refer [Ticket]
         CVE-2023-34040 refer [Ticket]
         CVE-2023-41080 refer [Ticket]
         CVE-2023-41329 refer [Ticket]
@@ -33,7 +32,6 @@
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-2976</cve>
     <cve>CVE-2023-34034</cve>
-    <cve>CVE-2020-8908</cve>
     <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-41329</cve>
     <cve>CVE-2023-41327</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4970

### Change description ###

updated gauva library and removed suppression

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
