### PR TITLE
CCD-4969: bumped spring-security.version to v5.7.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ ext {
 }
 
 ext['spring-framework.version'] = '5.3.27'
-ext['spring-security.version'] = '5.7.8'
+ext['spring-security.version'] = '5.7.10'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.14.1'
 ext['snakeyaml.version'] = '2.0'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -8,7 +8,6 @@
         CVE-2023-20883 refer [Ticket]
         CVE-2023-35116 refer [Ticket]
         CVE-2023-2976 refer [Ticket]
-        CVE-2023-34034 refer [Ticket]
         CVE-2023-34040 refer [Ticket]
         CVE-2023-41080 refer [Ticket]
         CVE-2023-41329 refer [Ticket]
@@ -21,16 +20,15 @@
         CVE-2023-45648 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
         CVE-2023-5072 refer [Ticket]
-    
         CVE-2023-33202 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
-        CVE-2023-6378 refer [Ticket]</notes>
+        CVE-2023-6378 refer [Ticket]
+    </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2023-20873</cve>
     <cve>CVE-2023-20883</cve>
     <cve>CVE-2023-35116</cve>
-    <cve>CVE-2023-34034</cve>
     <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-41329</cve>
     <cve>CVE-2023-41327</cve>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -24,6 +24,7 @@
         CVE-2023-6378 refer [Ticket]
         CVE-2023-33202 refer https://tools.hmcts.net/jira/browse/CCD-5136
         CVE-2023-34055 refer https://tools.hmcts.net/jira/browse/CCD-5135
+        CVE-2023-34042 refer [Ticket]
     </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2023-35116</cve>
@@ -32,5 +33,6 @@
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-33202</cve>
     <cve>CVE-2023-34055</cve>
+    <cve>CVE-2023-34042</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

CCD-4969

### Change description ###

bumped spring-security.version to v5.7.10

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
