### PR TITLE
Updating wiremock as there are 2 seperate CVEs for this issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,7 +186,7 @@ dependencies {
   }
 
   // https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock
-  implementation(group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.35.0')
+  implementation(group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.35.2')
 // https://mvnrepository.com/artifact/com.github.jknack/handlebars
   implementation group: 'com.github.jknack', name: 'handlebars', version: '4.3.1'
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -8,7 +8,6 @@
         CVE-2023-2976 refer [Ticket]
         CVE-2023-34040 refer [Ticket]
         CVE-2023-41080 refer [Ticket]
-        CVE-2023-41329 refer [Ticket]
         CVE-2023-41327 refer [Ticket]
         CVE-2023-36479 refer [Ticket]
         CVE-2023-41900 refer [Ticket]
@@ -28,7 +27,6 @@
     </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2023-35116</cve>
-    <cve>CVE-2023-41329</cve>
     <cve>CVE-2023-41327</cve>
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-33202</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###
[CCD-5205](https://tools.hmcts.net/jira/browse/CCD-5205)


### Change description ###
Upped version of wiremock to resolve CVE. Both CVEs CVE-2023-41327 and CVE-2023-41329 are for the same issue so raised separate PRs to remove the suppressions.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
