### PR TITLE
CCD-4373:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,12 @@ dependencies {
   }
 
   // https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock
-  implementation(group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.35.2')
+  implementation(group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.35.2') {
+    exclude group: 'com.jayway.jsonpath', module: 'json-path'
+  }
+
+  implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.9.0'
+
 // https://mvnrepository.com/artifact/com.github.jknack/handlebars
   implementation group: 'com.github.jknack', name: 'handlebars', version: '4.3.1'
 
@@ -231,7 +236,9 @@ dependencies {
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
   testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
 
-  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
+  testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test') {
+    exclude group:'com.jayway.jsonpath', module: 'json-path'
+  }
   testImplementation(group: 'io.rest-assured', name: 'rest-assured', version: '4.3.0') {
     exclude group: 'org.apache.sling', module: 'org.apache.sling.javax.activation'
   }

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
         CVE-2023-5072 refer [Ticket]
-    
         CVE-2024-38820 refer [Ticket]</notes>
-    <cve>CVE-2022-45688</cve>
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2024-38820</cve>
   </suppress>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-4373


### Change description ###
Fix CVE-2022-45688, removed json-path from wiremock-jre8 and spring-boot-starter-test and added in json-path 2.9.0


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
