### PR TITLE
Onboard CVE dashboard ingestion

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -11,7 +11,7 @@ properties(
   ]
 )
 
-@Library("Infrastructure@2.4.0")
+@Library("Infrastructure@cve-dashboard")
 
 def type = "java"
 def product = "ccd"
@@ -22,6 +22,7 @@ def branchesToSync = ['demo', 'ithc', 'perftest']
 env.TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX = "hmctsprod.azurecr.io/imported/"
 
 withPipeline(type, product, component) {
+  enableCveDashboardIngestion()
   onMaster {
     enableSlackNotifications('#ccd-master-builds')
     env.WIREMOCK_SERVER_MAPPINGS_PATH = "wiremock"


### PR DESCRIPTION
## Summary
- pin the shared Jenkins library to cve-dashboard, now based on version 2.4.9
- enable CVE dashboard ingestion for the first time

## Testing
- Jenkinsfile-only configuration change